### PR TITLE
Refactore: game detail page styling

### DIFF
--- a/app/components/modules/ConferenceStandings/ConferenceStandings.module.scss
+++ b/app/components/modules/ConferenceStandings/ConferenceStandings.module.scss
@@ -44,6 +44,7 @@
   gap: 16px;
   height: inherit;
   width: 200px;
+  overflow: hidden;
 
   @include s {
     width: 300px;

--- a/app/components/modules/ConferenceStandings/ConferenceStandings.tsx
+++ b/app/components/modules/ConferenceStandings/ConferenceStandings.tsx
@@ -31,7 +31,7 @@ const ConferenceStandings: FC<ConferenceStandingsProps> = ({
           </tr>
         </thead>
         <tbody>
-          {data.response.map((item: any, index: any) => (
+          {data?.response.map((item: any, index: any) => (
             <tr key={index}>
               <td className={styles.rankColumn}>{item.conference.rank}</td>
               <td className={styles.logoName}>

--- a/app/components/modules/GameStats/GameStats.module.scss
+++ b/app/components/modules/GameStats/GameStats.module.scss
@@ -4,7 +4,14 @@
   flex-wrap: nowrap;
   align-items: flex-end;
   gap: 48px;
-  margin: 96px auto;
+  border: 2px solid #e9e9e9;
+  border-radius: 12px;
+  width: fit-content;
+  padding: 16px;
+
+  @include s {
+    padding: 24px;
+  }
 }
 
 .teamLogo {

--- a/app/components/modules/QuarterScoring/QuarterScoring.module.scss
+++ b/app/components/modules/QuarterScoring/QuarterScoring.module.scss
@@ -1,11 +1,9 @@
 .quarterScoring {
   overflow-x: auto;
-  margin: 32px;
   display: flex;
   justify-content: center;
 
   @include m {
-    margin: 64px;
     justify-content: flex-end;
   }
 }

--- a/app/matchup/[matchup]/page.module.scss
+++ b/app/matchup/[matchup]/page.module.scss
@@ -1,0 +1,12 @@
+.gameInfoWrapper {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 32px;
+  margin: 32px;
+
+  @include m {
+    margin: 64px;
+    gap: 64px;
+  }
+}

--- a/app/matchup/[matchup]/page.tsx
+++ b/app/matchup/[matchup]/page.tsx
@@ -1,13 +1,16 @@
 import StageMatchDetails from "@/app/components/modules/StageMatchDetails/StageMatchDetails";
 import GameStats from "@/app/components/modules/GameStats/GameStats";
 import QuarterScoring from "@/app/components/modules/QuarterScoring/QuarterScoring";
+import styles from "./page.module.scss";
 
 const Matchup = ({ params: { matchup } }) => {
   return (
     <div>
       <StageMatchDetails id={matchup} />
-      <QuarterScoring id={matchup} />
-      <GameStats id={matchup} />
+      <div className={styles.gameInfoWrapper}>
+        <QuarterScoring id={matchup} />
+        <GameStats id={matchup} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### This PR adds:
* fix for scroll bars appearing in conference standings for large logos
* fixes error for conference standings when data is empty
* adjusted styling on match detail pages